### PR TITLE
Modernize svg2ico for current Inkscape and multi-size Windows icon export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 1.0.0 - 2026-06-08
+
+- Updated the extension to work with modern Inkscape `Save As` output handling
+- Fixed export flow so the extension renders the SVG before packaging icon output
+- Reworked ICO generation to export a multi-size Windows icon by default
+- Embedded icon sizes: `16`, `24`, `32`, `48`, `64`, `128`, `256`
+- Removed the legacy size-selection prompt during export
+- Updated output metadata for current ICO export behavior
+- Preserved attribution to the original author, Maurizio Aru

--- a/README.md
+++ b/README.md
@@ -1,12 +1,51 @@
 # svg2ico
 
-Inkscape extension to save image to WinIco file.
+Inkscape extension for exporting SVG artwork as a Windows `.ico` file.
 
-## How to install
+Original extension by [Maurizio Aru](https://github.com/ginopc). This fork updates the extension for modern Inkscape and modern Windows icon expectations while preserving the original project and license credit.
 
-Estract files from archive and copy them under Inkscape extesions folder.
+Current fork version: `1.0.0`
 
-## About
+## What's Improved
 
-* Author: [Maurizio Aru](https://github.com/ginopc)
+- Works with current Inkscape `File > Save As` output extension flow
+- Exports a multi-size `.ico` by default
+- Embeds these icon sizes in one file:
+  `16`, `24`, `32`, `48`, `64`, `128`, `256`
+- Removes the old extra options prompt during export
 
+## Installation
+
+Copy these files into your Inkscape user extensions folder:
+
+- `svg2ico.inx`
+- `svg2ico.py`
+
+On Windows this is usually:
+
+`%AppData%\inkscape\extensions`
+
+Then restart Inkscape.
+
+## Usage
+
+In Inkscape:
+
+1. Open your SVG.
+2. Choose `File > Save As...`
+3. Select `Win Icon File (*.ico)`.
+4. Save the file.
+
+The exported `.ico` contains multiple embedded sizes so Windows can choose the most appropriate one automatically.
+
+## Notes
+
+- This extension targets Windows `.ico` output.
+- The largest embedded icon size is `256x256`, which is the practical top-end for Windows ICO content.
+
+## Attribution
+
+- Original author: [Maurizio Aru](https://github.com/ginopc)
+- Modernization and compatibility updates: this fork
+
+See [CHANGELOG.md](./CHANGELOG.md) for a summary of fork changes.

--- a/svg2ico.inx
+++ b/svg2ico.inx
@@ -3,15 +3,9 @@
     <_name>SVG to ICO</_name>
     <id>org.inkscape.output.svg2ico</id>
     <dependency type="executable" location="extensions">svg2ico.py</dependency>
-    <param name="s" type="optiongroup" _gui-text="Select Size:">
-        <option value="16">16x16</option>
-        <option value="32">32x32</option>
-        <option value="48">48x48</option>
-    </param>
-    <param name="o" type="string" _gui-text="To File:">file.ico</param>
     <output>
         <extension>.ico</extension>
-        <mimetype>image/ico</mimetype>
+        <mimetype>image/vnd.microsoft.icon</mimetype>
         <_filetypename>Win Icon File (*.ico)</_filetypename>
         <_filetypetooltip>Icon file on Win format</_filetypetooltip>
     </output>

--- a/svg2ico.py
+++ b/svg2ico.py
@@ -5,9 +5,9 @@
 # Create Win ico files easily.
 #
 # Copyright (C) 2008 Maurizio Aru <ginopc(a)tiscali.it>
-# 
+#
 # Based on icon_generator code extesion by David R. Damerell (david@nixbioinf.org)
-# 
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
@@ -22,59 +22,115 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-__version__ = "0.2"
+__version__ = "1.0.0"
 
 import os
-import sys
-import subprocess
-import argparse
+import struct
 
-#
-# Sgv2Ico Main Class
-#
-class Svg2Ico:
-	
-	width = 16
-	heigth = 16
-	ifName = 'in.png'
-	ofName = 'out.ico'
-	
-	def __init__(self, size, iName):
-		self.width = size
-		self.heigth = size
-		self.ifName = iName
-	   
-	def createPPM(pnfFileName, isAlphaChannel):
-		return 0
-		
-	def resizeImage(self, iFile, oFile, width):
-	   return 0
-	   
-	def convertToIco(self, iFile):
-		return 0
-	   
-	def saveToFilename(self, fName):
-		self.ofName = fName
-		print("[DEBUG] Width: %d, Heigth: %d" % (self.width, self.heigth))
-		print("[DEBUG] iFile: %s, oFile: %s" % (self.ifName, self.ofName))
-		from PIL import Image
-		img = Image.open(self.ifName)
-		img.save(fName)
+import inkex
+from inkex.command import take_snapshot
+from PIL import Image
 
-#
-# Check command line parameters
-# 
-def parseOptions():
-	parser = argparse.ArgumentParser(description='Convert svg to ico')
-	parser.add_argument('--s', type=int, default=16, help='Icon Size')
-	parser.add_argument('--o', default="file.ico", help='Output FileName')
-	parser.add_argument('iFile', default="file.png", help='Input FileName')
-	args = parser.parse_args()
-	return args
 
-		
-if __name__ == '__main__':   #pragma: no cover
-	args = parseOptions()
-	e = Svg2Ico(args.s, args.iFile)
-	e.saveToFilename(args.o)
+class Svg2Ico(inkex.OutputExtension):
+    icon_sizes = (16, 24, 32, 48, 64, 128, 256)
 
+    def save(self, stream):
+        entries = []
+        try:
+            for size in self.icon_sizes:
+                entries.append(self.render_icon_image(size))
+            self.write_ico(entries, stream)
+        finally:
+            for _, png_name in entries:
+                if os.path.exists(png_name):
+                    os.unlink(png_name)
+
+    def render_icon_image(self, size):
+        png_name = take_snapshot(
+            self.document,
+            self.tempdir,
+            name="svg2ico-{0}".format(size),
+            ext="png",
+            export_width=size,
+            export_height=size,
+        )
+
+        with Image.open(png_name) as img:
+            icon = img.convert("RGBA")
+            if icon.size != (size, size):
+                icon = icon.resize((size, size), Image.Resampling.LANCZOS)
+            return self.ico_image_data(icon), png_name
+
+    @staticmethod
+    def ico_image_data(img):
+        width, height = img.size
+        xor_rows = []
+        and_rows = []
+        rgba = img.load()
+        mask_stride = ((width + 31) // 32) * 4
+
+        for y in range(height - 1, -1, -1):
+            xor_row = bytearray()
+            mask_row = bytearray(mask_stride)
+
+            for x in range(width):
+                r, g, b, a = rgba[x, y]
+                xor_row.extend((b, g, r, a))
+                if a == 0:
+                    mask_row[x // 8] |= 0x80 >> (x % 8)
+
+            xor_rows.append(bytes(xor_row))
+            and_rows.append(bytes(mask_row))
+
+        xor_bitmap = b"".join(xor_rows)
+        and_bitmap = b"".join(and_rows)
+        return struct.pack(
+            "<IIIHHIIIIII",
+            40,
+            width,
+            height * 2,
+            1,
+            32,
+            0,
+            len(xor_bitmap) + len(and_bitmap),
+            0,
+            0,
+            0,
+            0,
+        ) + xor_bitmap + and_bitmap
+
+    @staticmethod
+    def write_ico(entries, stream):
+        header = struct.pack("<HHH", 0, 1, len(entries))
+        stream.write(header)
+
+        directory_size = 6 + (16 * len(entries))
+        offset = directory_size
+
+        for image_data, _ in entries:
+            dib_header = image_data[:40]
+            width = struct.unpack("<I", dib_header[4:8])[0]
+            height = struct.unpack("<I", dib_header[8:12])[0] // 2
+            icon_width = 0 if width == 256 else width
+            icon_height = 0 if height == 256 else height
+            entry = struct.pack(
+                "<BBBBHHII",
+                icon_width,
+                icon_height,
+                0,
+                0,
+                1,
+                32,
+                len(image_data),
+                offset,
+            )
+            stream.write(entry)
+            offset += len(image_data)
+
+        for image_data, _ in entries:
+            stream.write(image_data)
+
+
+if __name__ == "__main__":
+    Svg2Ico().run()


### PR DESCRIPTION
## Summary

This PR modernizes `svg2ico` so it works with current Inkscape `Save As` output handling and produces a more practical Windows `.ico` file for modern systems.

The original extension assumed an older export flow and only targeted a limited single-size icon workflow. This update keeps the original project intact while improving compatibility and output quality.

## Changes

- update the extension to use modern Inkscape output-extension behavior
- fix export handling so the SVG is rendered correctly before icon packaging
- export a multi-size `.ico` by default instead of a single embedded size
- embed these icon sizes in one file:
  - `16x16`
  - `24x24`
  - `32x32`
  - `48x48`
  - `64x64`
  - `128x128`
  - `256x256`
- remove the extra export prompt, since the extension now uses a sensible default size set
- update the `.inx` metadata for current ICO export behavior
- refresh the README and add a changelog
- preserve attribution to the original author, Maurizio Aru

## Why

Modern Windows icon usage benefits from a multi-resolution `.ico`, and current Inkscape versions expect output extensions to behave differently than this extension originally did.

This PR aims to make `svg2ico` feel like a native, up-to-date `Save As` option again.

## Notes

- the extension still targets Windows `.ico` output only
- the largest embedded size remains `256x256`, which is the practical top-end for Windows ICO content

## Attribution

Original extension by Maurizio Aru:
https://github.com/ginopc